### PR TITLE
Output stdout from long running task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ impl Command {
                           echo -n "."
                           sleep 5
                         done
+                        echo ""
                         "#
                     ),
                     self.cmd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,17 +64,17 @@ impl Command {
                     w,
                     indoc!(
                         r#"
-                        long_running_output=$(mktemp)
-                        export BASHTESTMD_LONG_RUNNING_OUTPUT=$long_running_output
-                        {} &> $long_running_output &
+                        output=$(mktemp)
+                        export BASHTESTMD_LONG_RUNNING_OUTPUT=$output
+                        {} &> $output &
                         background_process_pid=$!
-                        echo "Waiting for process with PID: $background_process_pid to have a match in $long_running_output"
-                        until grep -q -i {} $long_running_output
+                        echo "Waiting for process with PID: $background_process_pid to have a match in $output"
+                        until grep -q -i {} $output
                         do       
                           if ! ps $background_process_pid > /dev/null 
                           then
                             echo "The background process died, output:" >&2
-                            cat $long_running_output
+                            cat $output
                             exit 1
                           fi
                           echo -n "."

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ impl Command {
         writeln!(
             w,
             indoc!(
-            r#"
+                r#"
             check_and_output_long_running_output() {{
                 if [[ -n "$BASHTESTMD_LONG_RUNNING_OUTPUT" && -f "$BASHTESTMD_LONG_RUNNING_OUTPUT" ]]; then
                     echo "Output of the long running task:"
@@ -69,7 +69,8 @@ impl Command {
                 fi
             }}
             "#
-            ))?;
+            )
+        )?;
 
         if self.long_running {
             if let Some(wait_until) = &self.wait_until {


### PR DESCRIPTION
Tested with following markdown:


```markdown
This is how bashtestmd works.

You can start with long-running command

```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=PING
$ ping 8.8.8.8
```

And then do couple other commands.

This will just check exit code

```sh,test-ci
$ date
```

This will compare output

```bash,test-ci,bashtestmd:compare-output
$ echo "Hello world"
Hello world
```

and if output does not match, it will fail, and also prints output of the long running command

```bash,test-ci,bashtestmd:compare-output
$ whoami
super-root```


```

and output is:

```
Running: 'ping 8.8.8.8'
Waiting for process with PID: 33937 to have a match in /var/folders/cq/zfvc0h8s1199jjhrk2spc1mw0000gn/T/tmp.G4NeQNbryJ
.
Running: 'date'
Mon Sep  2 09:59:57 CEST 2024
Running: 'echo "Hello world"'
Running: 'whoami'
'super-root```
' not found in text:
'nikolai'
Output of the long running task:
PING 8.8.8.8 (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: icmp_seq=0 ttl=116 time=21.474 ms
64 bytes from 8.8.8.8: icmp_seq=1 ttl=116 time=15.565 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=116 time=22.328 ms
64 bytes from 8.8.8.8: icmp_seq=3 ttl=116 time=51.119 ms
64 bytes from 8.8.8.8: icmp_seq=4 ttl=116 time=19.185 ms
=========== END OF THE LONG RUNNING OUTPUT. Terminating...
demo-bash.sh: line 67: 33937 Terminated: 15          ping 8.8.8.8 >&$long_running_output
```