### PR TITLE
Record exit code of the command, so it is not overwritten by if statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
-      - run: cargo nextest run --workspace --all-features --no-tests warn
+      - run: cargo nextest run --workspace --all-features --no-tests=warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
-      - run: cargo nextest run --workspace --all-features
+      - run: cargo nextest run --workspace --all-features --no-tests warn


### PR DESCRIPTION

```
Submitting tx: 0: 0x86cc3e6daf536c48a6b0583075ccc3ddffeacdf68b7d9ab1494792446e77d686
thread 'main' panicked at /home/runner/work/sovereign-sdk-wip/sovereign-sdk-wip/crates/utils/sov-node-client/src/lib.rs:230:58:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Your batch was submitted to the sequencer for publication. Response: SubmitBatchReceipt { blob_hash: Hash("0x09babed8baa47af60f884f808efc6edd1c73b54ab7b0e553421e9ff450a490ac"), da_transaction_id: Variant0("5EA11C0B14769C801420476D4BE6C35CE1E76469B03BCC890499D37FF4E03A0C"), tx_hashes: [] }
Expected exit code 0, got 0
```